### PR TITLE
Validate types of field arguments

### DIFF
--- a/contexts/root_context.rb
+++ b/contexts/root_context.rb
@@ -7,7 +7,7 @@ class RootContext < Context
 
   def validate_field_present(field_name, schema)
     valid_fields = [schema[:query_type], schema[:mutation_type]].map(&:downcase)
-    puts valid_fields
+
     unless valid_fields.include? field_name.downcase
       raise Context::ValidationException, "#{field_name.downcase} is not a valid field on the root"
     end

--- a/contexts/type_context.rb
+++ b/contexts/type_context.rb
@@ -21,6 +21,25 @@ class TypeContext < Context
     unless arg
       raise Context::ValidationException, "#{key} argument does not exist on the #{field} field of #{@type}"
     end
+
+    validate_field_arg_type(key, value, arg[:type][:name])
+  end
+
+  def validate_field_arg_type(key, value, expected_type)
+    correct_type = case expected_type
+                   when "String"
+                     value.is_a? String
+                   when "Int"
+                     value.is_a? Integer
+                   when "Float"
+                     (value.is_a? Integer) || (value.is_a? Float)
+                   when "ID"
+                     value.is_a? String
+                   end
+
+    unless correct_type
+      raise Context::ValidationException, "Expected #{expected_type} type arg for #{key}, got #{value.class} (#{value})"
+    end
   end
 
   # TODO: Support  interfaces


### PR DESCRIPTION
Closes #2 

Now, trying this: 

```
query = "
  query {
    viewer {
      repositories(first: \"Foo\") {
        totalCount
      }
    }
  }
"
```

Gives

```
type_context.rb:41:in `validate_field_arg_type': Expected Int type arg for first, got String (Foo) (Context::ValidationException)
```