### PR TITLE
Hide Schema type, validator is now an object instead of a singleton class

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ It ensures:
 ## Example
 
 ```Ruby
-schema = Schema.new(JSON.parse(File.read("schema.json")))
-
+schema = JSON.parse(File.read("schema.json"))
 query = "
   query {
     viewer {
@@ -25,7 +24,8 @@ query = "
   }
 "
 
-QueryValidator.validate(schema, query)
+validator = QueryValidator.new(schema)
+validator.validate(query)
 ```
 ```
 => bar not present on RepositoryConnection (Context::ValidationException)
@@ -36,12 +36,12 @@ QueryValidator.validate(schema, query)
 Generating a schema and validating a 29 line query gives this benchmark:
 
 ```
-       user     system      total        real
-Generating schema  0.030000   0.000000   0.030000 (  0.036233)
-Validating query  0.000000   0.000000   0.000000 (  0.000569)
+                    user     system      total        real
+Creating validator  0.010000   0.000000   0.010000 (  0.007621)
+Validating a query  0.000000   0.000000   0.000000 (  0.000593)
 ```
 
-[Script used to create benchmark](https://gist.github.com/nwoodthorpe/f5e426f85f8a3bdf40ff992c46a9cd88)
+[Script used to create benchmark](https://gist.github.com/nwoodthorpe/f9885a78f837bf96eed274e2ff81ebac)
 
 ## TODO
 

--- a/query_validator.rb
+++ b/query_validator.rb
@@ -1,35 +1,39 @@
 require './contexts/context'
 require './contexts/root_context'
+require './schema'
 require './query_tokenizer'
 require './query_ast'
 
 class QueryValidator
   class ValidationException < Exception; end
 
-  class << self
-    def validate(schema, query)
-      @schema = schema
-      tokenizer = QueryTokenizer.new(query)
-      ast = QueryAST.build(tokenizer)
+  def initialize(schema)
+    @schema = Schema.new(schema)
+  end
 
-      validate_node(ast, RootContext.new)
+  def validate(query)
+    tokenizer = QueryTokenizer.new(query)
+    ast = QueryAST.build(tokenizer)
+
+    validate_node(ast, RootContext.new)
+  end
+
+  private
+
+  def validate_node(ast, parent_context)
+    # first, check if field is valid in parent context
+    # then check if args are valid
+    # then recursively validate body nodes
+    parent_context.validate_field_present(ast[:field], @schema)
+
+    ast[:arguments].each do |key, value|
+      parent_context.validate_field_arg(ast[:field], key, value, @schema)
     end
 
-    def validate_node(ast, parent_context)
-      # first, check if field is valid in parent context
-      # then check if args are valid
-      # then recursively validate body nodes
-      parent_context.validate_field_present(ast[:field], @schema)
+    ast_context = parent_context.get_context_for_field(ast[:field], @schema) || return
 
-      ast[:arguments].each do |key, value|
-        parent_context.validate_field_arg(ast[:field], key, value, @schema)
-      end
-
-      ast_context = parent_context.get_context_for_field(ast[:field], @schema) || return
-
-      ast[:body].each do |child_ast|
-        validate_node(child_ast, ast_context)
-      end
+    ast[:body].each do |child_ast|
+      validate_node(child_ast, ast_context)
     end
   end
 end


### PR DESCRIPTION
Having the user create the `Schema` object, then passing that into the validator made no sense.

Now we create a `Validator` object with the parsed JSON (plain ol' ruby object) as the argument. Then, we can validate queries using this validator object. Makes way more sense. :+1: