### PR TITLE
Ensure ast leafs are scalars

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,38 +6,47 @@ describe "Integration specs" do
   subject { QueryValidator.new(JSON.parse(File.read("schema.json"))) }
 
   context "passing queries" do
-    let(:query1) { "query { viewer { login }}" }
-    let(:query2) { "query { user(login: \"foo\") { login } }" }
-    let(:query3) { "query{viewer{login}}" }
-    let(:query4) { "query{viewer{login url issues(first: 5){totalCount}}}" }
+    @queries = [
+      "query { viewer { login }}",
+      "query { user(login: \"foo\") { login } }",
+      "query{viewer{login}}",
+      "query{viewer{login url issues(first: 5){totalCount}}}"
+    ]
 
-    it "suceeds" do
-      expect do
-        [query1, query2, query3, query4].each do |query|
-          subject.validate(query)
+    @queries.each do |query|
+      context "query: \"#{query}\"" do
+        it "succeeds" do
+          expect do
+            subject.validate(query)
+          end.to_not raise_exception
         end
-      end.to_not raise_exception
+      end
     end
   end
 
   context "failing queries" do
-    let(:query1) { "query{}" }
-    let(:query2) { "q" }
-    let(:query3) { "query {" }
-    let(:query4) { "query {}{}" }
-    let(:query5) { "query { foo }" }
-    let(:query6) { "query { user(login: 5)}" }
-    let(:query7) { "query { user(foo: 5)}" }
-    let(:query8) { "query {user(login: \"hello\"){}}" }
-    let(:query9) { "user" }
+    @queries = [
+      "query{}",
+      "q",
+      "query {",
+      "query {}{}",
+      "query { foo }",
+      "query { user(login: 5)}",
+      "query { user(foo: 5)}",
+      "query {user(login: \"hello\"){}}",
+      "user",
+      "query { viewer }",
+      "query"
+    ]
 
-    it "raises exception" do
-      [query1, query2, query3, query4, query5,
-      query6, query7, query8, query9].each do |query|
-        expect do
-          subject.validate(query)
-        end.to raise_exception
-        #TODO: Catch specific exception here. Validator needs to wrap all exceptions first
+    @queries.each do |query|
+      context "query: \"#{query}\"" do
+        it "raises exception" do
+          expect do
+            subject.validate(query)
+          end.to raise_exception
+          #TODO: Catch specific exception here. Validator needs to wrap all exceptions first
+        end
       end
     end
   end

--- a/src/query_validator.rb
+++ b/src/query_validator.rb
@@ -21,9 +21,6 @@ class QueryValidator
   private
 
   def validate_node(ast, parent_context)
-    # first, check if field is valid in parent context
-    # then check if args are valid
-    # then recursively validate body nodes
     parent_context.validate_field_present(ast[:field], @schema)
 
     ast[:arguments].each do |key, value|
@@ -32,8 +29,12 @@ class QueryValidator
 
     ast_context = parent_context.get_context_for_field(ast[:field], @schema) || return
 
-    ast[:body].each do |child_ast|
-      validate_node(child_ast, ast_context)
+    if ast[:body].empty?
+      raise Context::ValidationException, "Object \"#{@type} must have selections"
+    else
+      ast[:body].each do |child_ast|
+        validate_node(child_ast, ast_context)
+      end
     end
   end
 end


### PR DESCRIPTION
This now fails validation:

```
query {
  viewer
}
```

as all objects must have selections.